### PR TITLE
feat: add clock skew and userinfo id_token options

### DIFF
--- a/example/internal/mock/storage.go
+++ b/example/internal/mock/storage.go
@@ -299,3 +299,11 @@ func (c *ConfClient) RestrictAdditionalAccessTokenScopes() func(scopes []string)
 func (c *ConfClient) IsScopeAllowed(scope string) bool {
 	return false
 }
+
+func (c *ConfClient) UserInfoInIDToken() bool {
+	return false
+}
+
+func (c *ConfClient) ClockSkew() time.Duration {
+	return 0
+}

--- a/example/internal/mock/storage.go
+++ b/example/internal/mock/storage.go
@@ -300,7 +300,7 @@ func (c *ConfClient) IsScopeAllowed(scope string) bool {
 	return false
 }
 
-func (c *ConfClient) UserInfoInIDToken() bool {
+func (c *ConfClient) IDTokenUserinfoClaimsAssertion() bool {
 	return false
 }
 

--- a/pkg/oidc/token.go
+++ b/pkg/oidc/token.go
@@ -48,8 +48,8 @@ func EmptyAccessTokenClaims() AccessTokenClaims {
 	return new(accessTokenClaims)
 }
 
-func NewAccessTokenClaims(issuer, subject string, audience []string, expiration time.Time, id, clientID string) AccessTokenClaims {
-	now := time.Now().UTC()
+func NewAccessTokenClaims(issuer, subject string, audience []string, expiration time.Time, id, clientID string, skew time.Duration) AccessTokenClaims {
+	now := time.Now().UTC().Add(-skew)
 	if len(audience) == 0 {
 		audience = append(audience, clientID)
 	}
@@ -203,14 +203,14 @@ func EmptyIDTokenClaims() IDTokenClaims {
 	return new(idTokenClaims)
 }
 
-func NewIDTokenClaims(issuer, subject string, audience []string, expiration, authTime time.Time, nonce string, acr string, amr []string, clientID string) IDTokenClaims {
+func NewIDTokenClaims(issuer, subject string, audience []string, expiration, authTime time.Time, nonce string, acr string, amr []string, clientID string, skew time.Duration) IDTokenClaims {
 	audience = AppendClientIDToAudience(clientID, audience)
 	return &idTokenClaims{
 		Issuer:                              issuer,
 		Audience:                            audience,
 		Expiration:                          Time(expiration),
-		IssuedAt:                            Time(time.Now().UTC()),
-		AuthTime:                            Time(authTime),
+		IssuedAt:                            Time(time.Now().UTC().Add(-skew)),
+		AuthTime:                            Time(authTime.Add(-skew)),
 		Nonce:                               nonce,
 		AuthenticationContextClassReference: acr,
 		AuthenticationMethodsReferences:     amr,

--- a/pkg/op/client.go
+++ b/pkg/op/client.go
@@ -37,6 +37,8 @@ type Client interface {
 	RestrictAdditionalIdTokenScopes() func(scopes []string) []string
 	RestrictAdditionalAccessTokenScopes() func(scopes []string) []string
 	IsScopeAllowed(scope string) bool
+	UserInfoInIDToken() bool
+	ClockSkew() time.Duration
 }
 
 func ContainsResponseType(types []oidc.ResponseType, responseType oidc.ResponseType) bool {

--- a/pkg/op/client.go
+++ b/pkg/op/client.go
@@ -37,7 +37,7 @@ type Client interface {
 	RestrictAdditionalIdTokenScopes() func(scopes []string) []string
 	RestrictAdditionalAccessTokenScopes() func(scopes []string) []string
 	IsScopeAllowed(scope string) bool
-	UserInfoInIDToken() bool
+	IDTokenUserinfoClaimsAssertion() bool
 	ClockSkew() time.Duration
 }
 

--- a/pkg/op/mock/client.mock.go
+++ b/pkg/op/mock/client.mock.go
@@ -77,6 +77,20 @@ func (mr *MockClientMockRecorder) AuthMethod() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthMethod", reflect.TypeOf((*MockClient)(nil).AuthMethod))
 }
 
+// ClockSkew mocks base method
+func (m *MockClient) ClockSkew() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClockSkew")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// ClockSkew indicates an expected call of ClockSkew
+func (mr *MockClientMockRecorder) ClockSkew() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClockSkew", reflect.TypeOf((*MockClient)(nil).ClockSkew))
+}
+
 // DevMode mocks base method
 func (m *MockClient) DevMode() bool {
 	m.ctrl.T.Helper()
@@ -215,4 +229,18 @@ func (m *MockClient) RestrictAdditionalIdTokenScopes() func([]string) []string {
 func (mr *MockClientMockRecorder) RestrictAdditionalIdTokenScopes() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictAdditionalIdTokenScopes", reflect.TypeOf((*MockClient)(nil).RestrictAdditionalIdTokenScopes))
+}
+
+// UserInfoInIDToken mocks base method
+func (m *MockClient) UserInfoInIDToken() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UserInfoInIDToken")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// UserInfoInIDToken indicates an expected call of UserInfoInIDToken
+func (mr *MockClientMockRecorder) UserInfoInIDToken() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserInfoInIDToken", reflect.TypeOf((*MockClient)(nil).UserInfoInIDToken))
 }

--- a/pkg/op/mock/client.mock.go
+++ b/pkg/op/mock/client.mock.go
@@ -133,6 +133,20 @@ func (mr *MockClientMockRecorder) IDTokenLifetime() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IDTokenLifetime", reflect.TypeOf((*MockClient)(nil).IDTokenLifetime))
 }
 
+// IDTokenUserinfoClaimsAssertion mocks base method
+func (m *MockClient) IDTokenUserinfoClaimsAssertion() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IDTokenUserinfoClaimsAssertion")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IDTokenUserinfoClaimsAssertion indicates an expected call of IDTokenUserinfoClaimsAssertion
+func (mr *MockClientMockRecorder) IDTokenUserinfoClaimsAssertion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IDTokenUserinfoClaimsAssertion", reflect.TypeOf((*MockClient)(nil).IDTokenUserinfoClaimsAssertion))
+}
+
 // IsScopeAllowed mocks base method
 func (m *MockClient) IsScopeAllowed(arg0 string) bool {
 	m.ctrl.T.Helper()
@@ -229,18 +243,4 @@ func (m *MockClient) RestrictAdditionalIdTokenScopes() func([]string) []string {
 func (mr *MockClientMockRecorder) RestrictAdditionalIdTokenScopes() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestrictAdditionalIdTokenScopes", reflect.TypeOf((*MockClient)(nil).RestrictAdditionalIdTokenScopes))
-}
-
-// UserInfoInIDToken mocks base method
-func (m *MockClient) UserInfoInIDToken() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UserInfoInIDToken")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// UserInfoInIDToken indicates an expected call of UserInfoInIDToken
-func (mr *MockClientMockRecorder) UserInfoInIDToken() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserInfoInIDToken", reflect.TypeOf((*MockClient)(nil).UserInfoInIDToken))
 }

--- a/pkg/op/mock/storage.mock.impl.go
+++ b/pkg/op/mock/storage.mock.impl.go
@@ -184,3 +184,11 @@ func (c *ConfClient) RestrictAdditionalAccessTokenScopes() func(scopes []string)
 func (c *ConfClient) IsScopeAllowed(scope string) bool {
 	return false
 }
+
+func (c *ConfClient) UserInfoInIDToken() bool {
+	return false
+}
+
+func (c *ConfClient) ClockSkew() time.Duration {
+	return 0
+}

--- a/pkg/op/mock/storage.mock.impl.go
+++ b/pkg/op/mock/storage.mock.impl.go
@@ -185,7 +185,7 @@ func (c *ConfClient) IsScopeAllowed(scope string) bool {
 	return false
 }
 
-func (c *ConfClient) UserInfoInIDToken() bool {
+func (c *ConfClient) IDTokenUserinfoClaimsAssertion() bool {
 	return false
 }
 

--- a/pkg/op/token.go
+++ b/pkg/op/token.go
@@ -105,7 +105,7 @@ func CreateIDToken(ctx context.Context, issuer string, authReq AuthRequest, vali
 			return "", err
 		}
 		claims.SetAccessTokenHash(atHash)
-		if !client.UserInfoInIDToken() {
+		if !client.IDTokenUserinfoClaimsAssertion() {
 			scopes = removeUserinfoScopes(scopes)
 		}
 	}

--- a/pkg/op/token.go
+++ b/pkg/op/token.go
@@ -31,7 +31,7 @@ func CreateTokenResponse(ctx context.Context, authReq AuthRequest, client Client
 			return nil, err
 		}
 	}
-	idToken, err := CreateIDToken(ctx, creator.Issuer(), authReq, client.IDTokenLifetime(), accessToken, code, creator.Storage(), creator.Signer(), client.RestrictAdditionalIdTokenScopes())
+	idToken, err := CreateIDToken(ctx, creator.Issuer(), authReq, client.IDTokenLifetime(), accessToken, code, creator.Storage(), creator.Signer(), client)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func CreateAccessToken(ctx context.Context, tokenRequest TokenRequest, accessTok
 	if err != nil {
 		return "", 0, err
 	}
-	validity = exp.Sub(time.Now().UTC())
+	validity = exp.Add(client.ClockSkew()).Sub(time.Now().UTC())
 	if accessTokenType == AccessTokenTypeJWT {
 		token, err = CreateJWT(ctx, creator.Issuer(), tokenRequest, exp, id, creator.Signer(), client, creator.Storage())
 		return
@@ -83,7 +83,7 @@ func CreateBearerToken(tokenID, subject string, crypto Crypto) (string, error) {
 }
 
 func CreateJWT(ctx context.Context, issuer string, tokenRequest TokenRequest, exp time.Time, id string, signer Signer, client Client, storage Storage) (string, error) {
-	claims := oidc.NewAccessTokenClaims(issuer, tokenRequest.GetSubject(), tokenRequest.GetAudience(), exp, id, client.GetID())
+	claims := oidc.NewAccessTokenClaims(issuer, tokenRequest.GetSubject(), tokenRequest.GetAudience(), exp, id, client.GetID(), client.ClockSkew())
 	if client != nil {
 		restrictedScopes := client.RestrictAdditionalAccessTokenScopes()(tokenRequest.GetScopes())
 		privateClaims, err := storage.GetPrivateClaimsFromScopes(ctx, tokenRequest.GetSubject(), client.GetID(), removeUserinfoScopes(restrictedScopes))
@@ -95,17 +95,19 @@ func CreateJWT(ctx context.Context, issuer string, tokenRequest TokenRequest, ex
 	return utils.Sign(claims, signer.Signer())
 }
 
-func CreateIDToken(ctx context.Context, issuer string, authReq AuthRequest, validity time.Duration, accessToken, code string, storage Storage, signer Signer, restictAdditionalScopesFunc func([]string) []string) (string, error) {
-	exp := time.Now().UTC().Add(validity)
-	claims := oidc.NewIDTokenClaims(issuer, authReq.GetSubject(), authReq.GetAudience(), exp, authReq.GetAuthTime(), authReq.GetNonce(), authReq.GetACR(), authReq.GetAMR(), authReq.GetClientID())
-	scopes := restictAdditionalScopesFunc(authReq.GetScopes())
+func CreateIDToken(ctx context.Context, issuer string, authReq AuthRequest, validity time.Duration, accessToken, code string, storage Storage, signer Signer, client Client) (string, error) {
+	exp := time.Now().UTC().Add(client.ClockSkew()).Add(validity)
+	claims := oidc.NewIDTokenClaims(issuer, authReq.GetSubject(), authReq.GetAudience(), exp, authReq.GetAuthTime(), authReq.GetNonce(), authReq.GetACR(), authReq.GetAMR(), authReq.GetClientID(), client.ClockSkew())
+	scopes := client.RestrictAdditionalIdTokenScopes()(authReq.GetScopes())
 	if accessToken != "" {
 		atHash, err := oidc.ClaimHash(accessToken, signer.SignatureAlgorithm())
 		if err != nil {
 			return "", err
 		}
 		claims.SetAccessTokenHash(atHash)
-		scopes = removeUserinfoScopes(scopes)
+		if !client.UserInfoInIDToken() {
+			scopes = removeUserinfoScopes(scopes)
+		}
 	}
 	if len(scopes) > 0 {
 		userInfo, err := storage.GetUserinfoFromScopes(ctx, authReq.GetSubject(), authReq.GetClientID(), scopes)


### PR DESCRIPTION
add two options:
- clock skew (add to exp, sub from iat, auth_time, nbf)
- assert userinfo (profile, email, phone, address) claims into id_token (for clients breaking the specification https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims)