### PR TITLE
feat: Allow the use of custom discovery endpoint

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -26,8 +26,13 @@ var (
 )
 
 //Discover calls the discovery endpoint of the provided issuer and returns its configuration
-func Discover(issuer string, httpClient *http.Client) (*oidc.DiscoveryConfiguration, error) {
+//It accepts an optional argument "wellknownUrl" which can be used to overide the dicovery endpoint url
+func Discover(issuer string, httpClient *http.Client, wellKnownUrl ...string) (*oidc.DiscoveryConfiguration, error) {
+
 	wellKnown := strings.TrimSuffix(issuer, "/") + oidc.DiscoveryEndpoint
+	if len(wellKnownUrl) == 1 && wellKnownUrl[0] != "" {
+		wellKnown = wellKnownUrl[0]
+	}
 	req, err := http.NewRequest("GET", wellKnown, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Thanks for this solid library.
On some occasions public services will expose OAuth2/OIDC endpoint on custom uri which are different from the standard patern you use in the library. I'd like to propose a new constructor to create a RelyingParty instances based on custom endpoints, different than what would be computed by the discovery method.